### PR TITLE
MLW-947 

### DIFF
--- a/src/checkin/CheckInQueue.jsx
+++ b/src/checkin/CheckInQueue.jsx
@@ -112,7 +112,7 @@ class CheckInQueue extends React.Component {
           ] }
           rowData={ Object.values(this.props.patients) }
           rowSelectedActionCreators={[() => screeningActions.setLastScreeningQueue(this.props.screeningLocation), patientActions.setSelectedPatient, this.redirectToScreeningTaskList.bind(this)]}
-          searchFilterFields={['name.fullName']}
+          searchFilterFields={['name.fullName', 'name.reverseFullName']}
           sortFields={['name.givenName', 'name.familyName']}
           title="Check-In Queue"
         />

--- a/src/checkin/CheckInQueue.jsx
+++ b/src/checkin/CheckInQueue.jsx
@@ -98,17 +98,7 @@ class CheckInQueue extends React.Component {
 */}
         <CardList
           AdditionalSearchFilters={IdentifierFilters}
-          additionalSearchFilterFields={[
-            'identifiers.0.identifier',
-            'identifiers.1.identifier',
-            'identifiers.2.identifier',
-            'identifiers.3.identifier',
-            'identifiers.4.identifier',
-            'identifiers.5.identifier',
-            'identifiers.6.identifier',
-            'identifiers.7.identifier',
-            'identifiers.8.identifier'
-          ]}
+          additionalSearchFilterFields={[(patient) => patient.identifiers ? patient.identifiers.map(i => i.identifier) : null]}
           card={PatientCard}
           delayInterval={0}
           dispatch={this.props.dispatch}

--- a/src/patient/patientSagas.jsx
+++ b/src/patient/patientSagas.jsx
@@ -27,7 +27,8 @@ const createFromReportingRestRep = (restRep) => {
   patient.name = {
     givenName: restRep.first_name,
     familyName: restRep.last_name,
-    fullName: `${restRep.first_name} ${restRep.last_name}` 
+    fullName: `${restRep.first_name} ${restRep.last_name}`,
+    reverseFullName: `${restRep.last_name} ${restRep.first_name}` 
   };
 
   if (restRep.identifiers) {

--- a/src/screening/ScreeningQueue.jsx
+++ b/src/screening/ScreeningQueue.jsx
@@ -46,7 +46,7 @@ let ScreeningQueue = props => {
         onMountOtherActionCreators={onMountOtherActionCreators}
         rowData={props.rowData}
         rowSelectedActionCreators={[patientActions.setSelectedPatient, () => screeningActions.setLastScreeningQueue(props.location), ...props.rowSelectedActionCreators]}
-        searchFilterFields={['name.fullName']}
+        searchFilterFields={['name.fullName', 'name.reverseFullName']}
         sortFields={['name.givenName', 'name.familyName']}
         title={props.title}
       />


### PR DESCRIPTION
@mogoodrich 
Continuing from https://github.com/PIH/openmrs-pwa-apzu-ic3/pull/76/files
I believe the matchSorter searches each field as a standAlone, so even the function approach did not work. so while we see `familyName` and `givenName` as part of a larger scope, it sees it as two completely unrelated fields.
The alternative would be to merge those fields ie fullName `familyName + givenName` but as you pointed out that did not match in reverse order. I check the package doc, there's nothing on matching in reverse. An hack for now would be to have something like `reverseFullName` i.e `givenName + familyName`. 
It works but is definitely not a clean solution. this is just a POC PR for how it would be implemented